### PR TITLE
feat: using prebundled deps from @modern-js/utils

### DIFF
--- a/.changeset/tough-wombats-cover.md
+++ b/.changeset/tough-wombats-cover.md
@@ -1,0 +1,11 @@
+---
+"@modern-js/codesmith-api-app": patch
+"@modern-js/codesmith-api-git": patch
+"@modern-js/codesmith-api-npm": patch
+"@modern-js/codesmith-cli": patch
+"@modern-js/codesmith": patch
+"@modern-js/inquirer-types": patch
+"@modern-js/codesmith-tools": patch
+---
+
+feat: using prebundled deps from @modern-js/utils

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: install pnpm
-        run: npm i -g pnpm
+        run: npm i -g pnpm@6
 
       - name: build
         run: pnpm i

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -49,14 +49,12 @@
     "@modern-js/plugin-i18n": "^1.0.0",
     "comment-json": "^4.1.1",
     "extra": "^0.2.1",
-    "fs-extra": "^10.0.0",
     "inquirer": "8.1.3",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
-    "@types/fs-extra": "^9.0.12",
     "@types/inquirer": "^7.3.3",
     "@types/jest": "^26",
     "@types/lodash": "^4.14.172",

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
+    "@modern-js/utils": "^1.7.0",
     "@modern-js/codesmith": "workspace:^1.0.7",
     "@modern-js/codesmith-api-git": "workspace:^1.0.7",
     "@modern-js/codesmith-api-handlebars": "workspace:^1.0.7",
@@ -52,7 +53,6 @@
     "fs-extra": "^10.0.0",
     "inquirer": "8.1.3",
     "lodash": "^4.17.21",
-    "ora": "^5.4.1",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -51,8 +51,7 @@
     "extra": "^0.2.1",
     "fs-extra": "^10.0.0",
     "inquirer": "8.1.3",
-    "lodash": "^4.17.21",
-    "semver": "^7.3.5"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",
@@ -62,7 +61,6 @@
     "@types/jest": "^26",
     "@types/lodash": "^4.14.172",
     "@types/node": "^14",
-    "@types/semver": "^7.3.8",
     "typescript": "^4"
   },
   "modernConfig": {

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -48,7 +48,6 @@
     "@modern-js/inquirer-types": "workspace:^1.0.7",
     "@modern-js/plugin-i18n": "^1.0.0",
     "comment-json": "^4.1.1",
-    "execa": "^5.1.1",
     "extra": "^0.2.1",
     "fs-extra": "^10.0.0",
     "inquirer": "8.1.3",

--- a/packages/api/app/src/index.ts
+++ b/packages/api/app/src/index.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-// import ora from 'ora';
 import semver from 'semver';
 import execa from 'execa';
 import { merge } from 'lodash';

--- a/packages/api/app/src/index.ts
+++ b/packages/api/app/src/index.ts
@@ -1,6 +1,5 @@
 import fs from 'fs-extra';
-import semver from 'semver';
-import { execa } from '@modern-js/utils';
+import { execa, semver } from '@modern-js/utils';
 import { merge } from 'lodash';
 import { parse, stringify } from 'comment-json';
 import { GeneratorCore, GeneratorContext } from '@modern-js/codesmith';

--- a/packages/api/app/src/index.ts
+++ b/packages/api/app/src/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import semver from 'semver';
-import execa from 'execa';
+import { execa } from '@modern-js/utils';
 import { merge } from 'lodash';
 import { parse, stringify } from 'comment-json';
 import { GeneratorCore, GeneratorContext } from '@modern-js/codesmith';

--- a/packages/api/app/src/index.ts
+++ b/packages/api/app/src/index.ts
@@ -1,5 +1,4 @@
-import fs from 'fs-extra';
-import { execa, semver } from '@modern-js/utils';
+import { fs, execa, semver } from '@modern-js/utils';
 import { merge } from 'lodash';
 import { parse, stringify } from 'comment-json';
 import { GeneratorCore, GeneratorContext } from '@modern-js/codesmith';

--- a/packages/api/git/package.json
+++ b/packages/api/git/package.json
@@ -40,13 +40,11 @@
   "dependencies": {
     "@babel/runtime": "^7",
     "@modern-js/utils": "^1.7.0",
-    "@modern-js/codesmith": "workspace:^1.0.7",
-    "fs-extra": "^10.0.0"
+    "@modern-js/codesmith": "workspace:^1.0.7"
   },
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
-    "@types/fs-extra": "^9.0.12",
     "@types/jest": "^26",
     "@types/node": "^14",
     "typescript": "^4"

--- a/packages/api/git/package.json
+++ b/packages/api/git/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
+    "@modern-js/utils": "^1.7.0",
     "@modern-js/codesmith": "workspace:^1.0.7",
-    "execa": "^5.1.1",
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/api/git/src/utils/index.ts
+++ b/packages/api/git/src/utils/index.ts
@@ -1,4 +1,4 @@
-import execa from 'execa';
+import { execa } from '@modern-js/utils';
 
 export async function canUseGit() {
   try {

--- a/packages/api/git/tests/index.test.ts
+++ b/packages/api/git/tests/index.test.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
-import execa from 'execa';
+import { execa } from '@modern-js/utils';
 import {
   canUseGit,
   initGitRepo,

--- a/packages/api/git/tests/index.test.ts
+++ b/packages/api/git/tests/index.test.ts
@@ -1,7 +1,6 @@
 import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
-import { execa } from '@modern-js/utils';
+import { fs, execa } from '@modern-js/utils';
 import {
   canUseGit,
   initGitRepo,

--- a/packages/api/npm/package.json
+++ b/packages/api/npm/package.json
@@ -45,10 +45,8 @@
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
-    "@types/fs-extra": "^9.0.12",
     "@types/jest": "^26",
     "@types/node": "^14",
-    "fs-extra": "^10.0.0",
     "typescript": "^4"
   },
   "modernConfig": {

--- a/packages/api/npm/package.json
+++ b/packages/api/npm/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
-    "@modern-js/codesmith": "workspace:^1.0.7",
-    "execa": "^5.1.1"
+    "@modern-js/utils": "^1.7.0",
+    "@modern-js/codesmith": "workspace:^1.0.7"
   },
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",

--- a/packages/api/npm/src/utils/env.ts
+++ b/packages/api/npm/src/utils/env.ts
@@ -1,4 +1,4 @@
-import execa from 'execa';
+import { execa } from '@modern-js/utils';
 
 export async function canUseNvm() {
   try {

--- a/packages/api/npm/src/utils/install.ts
+++ b/packages/api/npm/src/utils/install.ts
@@ -1,4 +1,4 @@
-import execa from 'execa';
+import { execa } from '@modern-js/utils';
 import { canUseNpm, canUsePnpm, canUseYarn } from './env';
 
 export function execaWithStreamLog(

--- a/packages/api/npm/tests/utils.test.ts
+++ b/packages/api/npm/tests/utils.test.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import { canUseNvm, canUseNpm, canUseYarn } from '@/utils/env';
 import { npmInstall, yarnInstall, pnpmInstall } from '@/utils/install';
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,15 +44,14 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7",
+    "@modern-js/utils": "^1.7.0",
     "@modern-js/module-tools": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
     "@modern-js/codesmith": "workspace:^1.0.7",
     "@modern-js/codesmith-tools": "workspace:^1.0.7",
     "@modern-js/i18n-cli-language-detector": "^1.0.0",
-    "@types/commander": "^2.12.2",
     "@types/jest": "^26",
     "@types/node": "^14",
-    "commander": "^8.0.0",
     "ts-node": "^10.1.0",
     "typescript": "^4"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command } from '@modern-js/utils';
 import { genAction } from './actions/genAction';
 
 export default function () {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
     "@babel/runtime": "^7",
     "@modern-js/utils": "^1.7.0",
     "axios": "^0.21.1",
-    "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
     "glob-promise": "^4.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
     "@babel/runtime": "^7",
     "@modern-js/utils": "^1.7.0",
     "axios": "^0.21.1",
-    "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
     "glob-promise": "^4.2.0",
     "package-json": "^7.0.0",
@@ -48,7 +47,6 @@
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
-    "@types/fs-extra": "^9.0.12",
     "@types/jest": "^26",
     "@types/node": "^14",
     "@types/tar": "^4.0.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
     "@babel/runtime": "^7",
     "@modern-js/utils": "^1.7.0",
     "axios": "^0.21.1",
-    "chalk": "^4.1.1",
     "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,13 +37,13 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
+    "@modern-js/utils": "^1.7.0",
     "axios": "^0.21.1",
     "chalk": "^4.1.1",
     "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "glob": "^7.1.7",
     "glob-promise": "^4.2.0",
-    "ora": "^5.4.1",
     "package-json": "^7.0.0",
     "semver": "^7.3.5",
     "tar": "^6.1.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
     "glob": "^7.1.7",
     "glob-promise": "^4.2.0",
     "package-json": "^7.0.0",
-    "semver": "^7.3.5",
     "tar": "^6.1.1"
   },
   "devDependencies": {
@@ -52,7 +51,6 @@
     "@types/fs-extra": "^9.0.12",
     "@types/jest": "^26",
     "@types/node": "^14",
-    "@types/semver": "^7.3.8",
     "@types/tar": "^4.0.5",
     "typescript": "^4"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,8 +39,6 @@
     "@babel/runtime": "^7",
     "@modern-js/utils": "^1.7.0",
     "axios": "^0.21.1",
-    "glob": "^7.1.7",
-    "glob-promise": "^4.2.0",
     "package-json": "^7.0.0",
     "tar": "^6.1.1"
   },

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { EventEmitter } from 'events';
-import ora from 'ora';
-import chalk from 'chalk';
+import { ora, chalk } from '@modern-js/utils';
 import fs, { WriteFileOptions } from 'fs-extra';
 import { GeneratorContext, RuntimeCurrent } from './constants';
 import { Logger } from '@/logger';

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { EventEmitter } from 'events';
-import { ora, chalk } from '@modern-js/utils';
-import fs, { WriteFileOptions } from 'fs-extra';
+import { fs, ora, chalk } from '@modern-js/utils';
 import { GeneratorContext, RuntimeCurrent } from './constants';
 import { Logger } from '@/logger';
 import { ILogger } from '@/logger/constants';
@@ -27,7 +26,7 @@ export class GeneratorCore {
     fs: (
       file: string | number,
       data: any,
-      options?: WriteFileOptions | string,
+      options?: fs.WriteFileOptions | string,
     ) => Promise<void>;
   } = {
     fs: async (file, content, options) => {

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-console */
-import chalk from 'chalk';
+import { chalk } from '@modern-js/utils';
 import { ILogger, LevelPriority, LoggerLevel } from './constants';
 
 export class Logger implements ILogger {

--- a/packages/core/src/materials/FsMaterial.ts
+++ b/packages/core/src/materials/FsMaterial.ts
@@ -1,6 +1,17 @@
 import path from 'path';
-import glob from 'glob-promise';
+import { glob } from '@modern-js/utils';
 import { FsResource } from './FsResource';
+
+const promisifyGlob = function (
+  pattern: string,
+  options: glob.IOptions,
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    glob(pattern, options, (err, files) =>
+      err === null ? resolve(files) : reject(err),
+    );
+  });
+};
 
 export class FsMaterial {
   basePath: string;
@@ -24,7 +35,7 @@ export class FsMaterial {
       ignore?: string | readonly string[];
     },
   ): Promise<Record<string, FsResource>> {
-    const matches = await glob(globStr, {
+    const matches = await promisifyGlob(globStr, {
       cwd: path.resolve(this.basePath),
       nodir: options?.nodir,
       dot: options?.dot,

--- a/packages/core/src/materials/FsResource.ts
+++ b/packages/core/src/materials/FsResource.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { Buffer } from 'buffer';
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import { IMAGE_EXT_LIST } from './constants';
 
 export const FS_RESOURCE = '_codesmith_core_fs_resource';

--- a/packages/core/src/utils/downloadPackage.ts
+++ b/packages/core/src/utils/downloadPackage.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import axios from 'axios';
 import tar from 'tar';
 import { getNpmTarballUrl } from './getNpmTarballUrl';

--- a/packages/core/src/utils/fsExists.ts
+++ b/packages/core/src/utils/fsExists.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 
 /**
  * when the path can read successfully, the function will return true

--- a/packages/core/src/utils/getGeneratorDir.ts
+++ b/packages/core/src/utils/getGeneratorDir.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import { fsExists } from './fsExists';
 
 const MaxTimes = 5;

--- a/packages/core/src/utils/getPackageInfo.ts
+++ b/packages/core/src/utils/getPackageInfo.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import { semver } from '@modern-js/utils';
 
 /**
  * get package name and package version from package name string

--- a/packages/core/src/utils/packageManager.ts
+++ b/packages/core/src/utils/packageManager.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { execa } from '@modern-js/utils';
-import fs from 'fs-extra';
+import { fs, execa } from '@modern-js/utils';
 
 export async function canUseYarn() {
   try {

--- a/packages/core/src/utils/packageManager.ts
+++ b/packages/core/src/utils/packageManager.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import execa from 'execa';
+import { execa } from '@modern-js/utils';
 import fs from 'fs-extra';
 
 export async function canUseYarn() {

--- a/packages/core/tests/utils/downloadPackage.test.ts
+++ b/packages/core/tests/utils/downloadPackage.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import os from 'os';
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import { downloadPackage } from '@/utils';
 
 jest.setTimeout(100000);

--- a/packages/core/tests/utils/fsExists.test.ts
+++ b/packages/core/tests/utils/fsExists.test.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import { fsExists } from '@/utils';
 
 describe('fsExists function test', () => {

--- a/packages/core/tests/utils/getGeneratorDir.test.ts
+++ b/packages/core/tests/utils/getGeneratorDir.test.ts
@@ -1,6 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
-import * as fs from 'fs-extra';
+import { fs } from '@modern-js/utils';
 import { fsExists } from '@/utils';
 import { getGeneratorDir } from '@/utils/getGeneratorDir';
 

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
-    "chalk": "^4.1.1",
+    "@modern-js/utils": "^1.7.0",
     "cli-cursor": "^3.1.0",
     "inquirer": "8.1.3",
     "lodash": "^4.17.21",

--- a/packages/inquirer/src/list.ts
+++ b/packages/inquirer/src/list.ts
@@ -1,7 +1,7 @@
 import { Interface as ReadLineInterface } from 'readline';
 import { isNumber, findIndex } from 'lodash';
 import { Question, Answers } from 'inquirer';
-import chalk from 'chalk';
+import { chalk } from '@modern-js/utils';
 import cliCursor from 'cli-cursor';
 import runAsync from 'run-async';
 import Base from 'inquirer/lib/prompts/base';

--- a/packages/inquirer/src/utils/index.ts
+++ b/packages/inquirer/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { Answers } from 'inquirer';
-import chalk from 'chalk';
+import { chalk } from '@modern-js/utils';
 import OriginChoices from 'inquirer/lib/objects/choices';
 import { pointer as pointerCharacter } from './pointer';
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7",
+    "@modern-js/utils": "^1.7.0",
     "commander": "^8.0.0",
-    "ora": "^5.4.1",
     "webpack": "^5.33.2"
   },
   "devDependencies": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -44,13 +44,11 @@
   "dependencies": {
     "@babel/runtime": "^7",
     "@modern-js/utils": "^1.7.0",
-    "commander": "^8.0.0",
     "webpack": "^5.33.2"
   },
   "devDependencies": {
     "@modern-js/module-tools": "^1.0.0",
     "@modern-js/plugin-testing": "^1.0.0",
-    "@types/commander": "^2.12.2",
     "@types/jest": "^26",
     "@types/node": "^14",
     "ts-node": "^10.1.0",

--- a/packages/tools/src/commands/build.ts
+++ b/packages/tools/src/commands/build.ts
@@ -1,5 +1,5 @@
 import webpack from 'webpack';
-import ora from 'ora';
+import { ora } from '@modern-js/utils';
 import { getWebpackConfig } from '../constants';
 
 export async function build() {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command } from '@modern-js/utils';
 import { build } from './commands';
 
 export default function () {


### PR DESCRIPTION
使用 @modern-js/utils 中预打包的依赖：

- ora
- commander
- chalk
- execa
- semver
- fs-extra
- glob

### TODO

未处理 inquirer，因为 codesmith 中会直接引用 `inquirer/lib/xxx` 下的模块或类型，而 `@modern-js/utils` 中只导出了 inquirer 对象。

inquirer 是一个 install size 很大的包，后续要再处理下。