### PR TITLE
Release v2.0.4

### DIFF
--- a/.changeset/honest-sloths-return.md
+++ b/.changeset/honest-sloths-return.md
@@ -1,5 +1,0 @@
----
-'@modern-js/codesmith': patch
----
-
-feat: remove validate tar package length

--- a/packages/api/app/CHANGELOG.md
+++ b/packages/api/app/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @modern-js/codesmith-api-app
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+  - @modern-js/codesmith-api-ejs@2.0.4
+  - @modern-js/codesmith-api-fs@2.0.4
+  - @modern-js/codesmith-api-git@2.0.4
+  - @modern-js/codesmith-api-npm@2.0.4
+  - @modern-js/codesmith-formily@2.0.4
+  - @modern-js/codesmith-api-handlebars@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/app/package.json
+++ b/packages/api/app/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",
@@ -42,7 +42,7 @@
     "inquirer": "8.1.3"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.0.3"
+    "@modern-js/codesmith": "workspace:^2.0.4"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/ejs/CHANGELOG.md
+++ b/packages/api/ejs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-ejs
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/ejs/package.json
+++ b/packages/api/ejs/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",
@@ -32,7 +32,7 @@
     "ejs": "^3.1.8"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.0.3"
+    "@modern-js/codesmith": "workspace:^2.0.4"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/fs/CHANGELOG.md
+++ b/packages/api/fs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-fs
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/fs/package.json
+++ b/packages/api/fs/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",
@@ -31,7 +31,7 @@
     "@babel/runtime": "^7"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.0.3"
+    "@modern-js/codesmith": "workspace:^2.0.4"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/git/CHANGELOG.md
+++ b/packages/api/git/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-git
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/git/package.json
+++ b/packages/api/git/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",
@@ -32,7 +32,7 @@
     "@modern-js/utils": "^1.19.0"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.0.3"
+    "@modern-js/codesmith": "workspace:^2.0.4"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/api/handlebars/CHANGELOG.md
+++ b/packages/api/handlebars/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-handlebars
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/handlebars/package.json
+++ b/packages/api/handlebars/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",
@@ -32,7 +32,7 @@
     "handlebars": "^4.7.7"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.0.3"
+    "@modern-js/codesmith": "workspace:^2.0.4"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace: *",

--- a/packages/api/json/CHANGELOG.md
+++ b/packages/api/json/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-json
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/json/package.json
+++ b/packages/api/json/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/api/npm/CHANGELOG.md
+++ b/packages/api/npm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-api-npm
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/api/npm/package.json
+++ b/packages/api/npm/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/codesmith-cli
 
+## 2.0.4
+
 ## 2.0.3
 
 ## 2.0.2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @modern-js/codesmith
 
+## 2.0.4
+
+### Patch Changes
+
+- e95bf71: feat: remove validate tar package length
+
 ## 2.0.3
 
 ## 2.0.2

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",

--- a/packages/formily/CHANGELOG.md
+++ b/packages/formily/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @modern-js/codesmith-formily
 
+## 2.0.4
+
+### Patch Changes
+
+- Updated dependencies [e95bf71]
+  - @modern-js/codesmith@2.0.4
+
 ## 2.0.3
 
 ### Patch Changes

--- a/packages/formily/package.json
+++ b/packages/formily/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",
@@ -45,7 +45,7 @@
     "@formily/validator": "^2.2.6"
   },
   "peerDependencies": {
-    "@modern-js/codesmith": "workspace:^2.0.3"
+    "@modern-js/codesmith": "workspace:^2.0.4"
   },
   "devDependencies": {
     "@modern-js/codesmith": "workspace:*",

--- a/packages/inquirer/CHANGELOG.md
+++ b/packages/inquirer/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @modern-js/inquirer-types
 
+## 2.0.4
+
 ## 2.0.3
 
 ## 2.0.2

--- a/packages/inquirer/package.json
+++ b/packages/inquirer/package.json
@@ -11,7 +11,7 @@
     "modern",
     "modern.js"
   ],
-  "version": "2.0.3",
+  "version": "2.0.4",
   "jsnext:source": "./src/index.ts",
   "types": "./dist/types/index.d.ts",
   "main": "./dist/js/node/index.js",


### PR DESCRIPTION

# Release v2.0.4



## Features:

- [#81](https://github.com/modern-js-dev/codesmith/pull/81) feat: remove validate tar package length

